### PR TITLE
Add required version field

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -53,12 +53,14 @@
   },
   "type": "object",
   "required": [
+    "version",
     "community_node_account_name",
     "org",
     "nodes"
   ],
   "additionalProperties": false,
   "properties": {
+    "version": "string",
     "community_node_account_name": {
       "$id": "/properties/community_node_account_name",
       "description": "Communit Node Account name",


### PR DESCRIPTION
In order to identify a particular Access Node's use of the json info, against a particular version of the schema, we need a version in the info block itself.